### PR TITLE
Add API token documentation

### DIFF
--- a/Example/Example/AppDelegate.swift
+++ b/Example/Example/AppDelegate.swift
@@ -27,6 +27,7 @@ extension AppDelegate {
         try? Salemove.sharedInstance.configure(site: "YOUR_SITE")
         try? Salemove.sharedInstance.configure(environment: "YOUR_ENVIRONMENT")
         try? Salemove.sharedInstance.configure(appToken: "YOUR_TOKEN")
+        try? Salemove.sharedInstance.configure(apiToken: "YOUR_API_TOKEN")
     }
 }
 

--- a/docs/2017-11-28-Enhancing+Your+iOS+Application+With+Salmove+SDK.md
+++ b/docs/2017-11-28-Enhancing+Your+iOS+Application+With+Salmove+SDK.md
@@ -84,6 +84,7 @@ func configureSalemove() {
   try? Salemove.sharedInstance.configure(site: "72bd8093-eae1-4f31-88c1-0c3132eb0906")
   try? Salemove.sharedInstance.configure(environment: "https://api.salemove.com/")
   try? Salemove.sharedInstance.configure(appToken: "sEQaZ6S2ULiFGK9F")
+  try? Salemove.sharedInstance.configure(apiToken: "sRh5M2NN90p_W03Hs")
 }
 ```
 

--- a/docs/Setup.md
+++ b/docs/Setup.md
@@ -33,11 +33,16 @@ The SalemoveSDK is not using Bitcode so this should be disabled for the project.
 
 ### SDK Configuration
 
-he SalemoveSDK accepts three configuration options:
+he SalemoveSDK accepts four configuration options:
+
+- In order to configure the developer APP token used by the SDK:
+```swift
+func configure(appToken: String)
+```
 
 - In order to configure the developer API token used by the SDK:
 ```swift
-func configure(appToken: String)
+func configure(apiToken: String)
 ```
 
 - In order to configure the environment used by the SDK:


### PR DESCRIPTION
The new SDK build includes a way of configuring the API token. This information is now present in the documentation