### PR TITLE
Add screensharing mirroring information

### DIFF
--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -3,7 +3,6 @@
 This is a list of questions we frequently get and problems that are often encountered. 
 
 * [Example app not compiling](#example-app-not-compiling)
-* [Why do we include a custom socket.io library](#why-do-we-include-a-custom-socket-library)
 * [Why do we include 3rd party dependencies when using Carthage?](#why-do-we-include-3rd-party-dependencies-when-using-carthage)
 * [What to do if your App does not support latest Swift and Xcode?](#what-to-do-if-your-app-does-not-support-latest-swift-and-xcode)
 

--- a/docs/Screensharing.md
+++ b/docs/Screensharing.md
@@ -7,7 +7,7 @@ See [explanation video][0]
 ## Setup
 
 - An iOS device running iOS 11.0+ (on earlier versions no screensharing is possible)
-- No active Screencast or Airplay enabled on the device
+- No active Screencast, Airplay or Quicktime mirror enabled on the device
 
 ## Annotations
 


### PR DESCRIPTION

Another use case when screensharing is not available is when
Quicktime is used to record the screen so this should be clearly
stated in the docs

SSD-4894