### PR TITLE
Update post-release workflow

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -1,0 +1,23 @@
+---
+format_version: '6'
+default_step_lib_source: 'https://github.com/bitrise-io/bitrise-steplib.git'
+project_type: ios
+trigger_map:
+- tag: '*.*.*'
+  workflow: post-release
+workflows:
+  post-release:
+    steps:
+    - set-env-var@0:
+        inputs:
+        - destination_keys: NEW_VERSION
+        - value: $BITRISE_GIT_TAG
+    - trigger-bitrise-workflow@0:
+        inputs:
+        - api_token: $GLIA_IOS_PODSPECS_BUILD_TRIGGER_TOKEN
+        - workflow_id: upload_core_sdk_podspec
+        - exported_environment_variable_names: NEW_VERSION
+        - app_slug: $GLIA_IOS_PODSPECS_APP_SLUG
+meta:
+  bitrise.io:
+    stack: osx-xcode-13.2.x


### PR DESCRIPTION
Because tm-compsec has fixed the issues about SSH, we can now call workflows in other projects through the Bitrise-native step `trigger-bitrise-workflow`. This will call a workflow in glia-ios-podspecs to create a new podspec with the new version. There is no need to create a GitHub Action for this because the ios-sdk release process automatically creates a tag in ios-bundle, which will then trigger this post-release workflow.

MOB-1589