### PR TITLE
Change stack for ios-bundle

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -103,4 +103,5 @@ workflows:
         - content: pod trunk push GliaCoreSDK.podspec --verbose
 meta:
   bitrise.io:
-    stack: osx-xcode-13.2.x
+    stack: osx-xcode-14.2.x-ventura
+    machine_type_id: g2-m1.4core


### PR DESCRIPTION
We were building with older stack with Xcode 13.2 and Intel machines in Bitrise. These have been deprecated by them, and it was causing issues in sending the SDK to Cocoapods.