### PR TITLE
Add GliaOpenTelemetry dependency to GliaCoreSDK

### DIFF
--- a/GliaCoreSDK.podspec
+++ b/GliaCoreSDK.podspec
@@ -16,4 +16,5 @@ Pod::Spec.new do |s|
   s.dependency 'GliaCoreDependency', '2.4.0'
   s.dependency 'WebRTC-lib', '119.0.0'
   s.dependency 'TwilioVoice', '6.8.0'
+  s.dependency 'GliaOpenTelemetry', '0.1.1'
 end

--- a/Package.swift
+++ b/Package.swift
@@ -13,6 +13,9 @@ let package = Package(
             targets: ["GliaSDK"]
         )
     ],
+    dependencies: [
+        .package(url: "https://github.com/salemove/opentelemetry-swift.git", .revision("baa983d7b790cde47a3b338b72ede7e44f9770d0")),
+    ],
     targets: [
         .binaryTarget(
             name: "GliaCoreDependency",
@@ -34,13 +37,19 @@ let package = Package(
             url: "https://github.com/salemove/ios-bundle/releases/download/2.2.3/GliaCoreSDK.xcframework.zip",
             checksum: "195040645748ec7232a1c0ab7c9a82a05226f99a921d66ac0dfd7210a3c050d9"
         ),
+         .binaryTarget(
+            name: "GliaOpenTelemetry",
+            url: "https://github.com/salemove/ios-bundle/releases/download/2.1.5/GliaOpenTelemetry.xcframework.zip",
+            checksum: "4b407063fef1265bb4c14d230a99fe7c90a45cb74730d47aad4bd63f838345e6"
+        ),
         .target(
             name: "GliaSDK",
             dependencies: [
                 "GliaCoreSDK",
                 "GliaCoreDependency",
                 "TwilioVoice",
-                "WebRTC"
+                "WebRTC",
+                "GliaOpenTelemetry"
             ]
         )
     ]


### PR DESCRIPTION
Changed the hash to newest 1.0.1 release. 